### PR TITLE
go.mod: bump go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/cockroachdb/logtags
 
-go 1.16
+go 1.18


### PR DESCRIPTION
Use of `any` requires go 1.18+.